### PR TITLE
Add support for Bluebird 3

### DIFF
--- a/lib/provider.js
+++ b/lib/provider.js
@@ -66,7 +66,7 @@ function Provider (options) {
     if (!Promise) {
       throw new Error('Purest: bluebird is not installed!')
     } else {
-      this._request = Promise.promisify(Provider.request)
+      this._request = Promise.promisify(Provider.request, {multiArgs:true})
     }
   }
   // debug


### PR DESCRIPTION
Bluebird 3's `promisify` no longer converts multi-argument callbacks to promises for arrays, as explained here: https://github.com/petkaantonov/bluebird/issues/826

This means errors get thrown when using Bluebird 3. The fix is just to pass `multiArgs: true` to `promisify`, which will be ignored by Bluebird 2 anyway.