### PR TITLE
fix google config file

### DIFF
--- a/config/providers.json
+++ b/config/providers.json
@@ -1115,7 +1115,7 @@
     },
     "contacts": {
       "origin": "https://www.google.com",
-      "path": "m8/feeds/{path",
+      "path": "m8/feeds/{path}",
       "headers": {
         "authorization": "Bearer {auth}",
         "GData-Version": "3.0"


### PR DESCRIPTION
Hi @simov 😄 
I've found a mispelled `{auth}` string in the providers.js file.