### PR TITLE
fix(providers): Okta add headers for oauth

### DIFF
--- a/config/providers.json
+++ b/config/providers.json
@@ -1740,7 +1740,10 @@
     "oauth": {
       "origin": "https://{subdomain}.okta.com",
       "path": "oauth2/{version}/{path}",
-      "version": "v1"
+      "version": "v1",
+      "headers": {
+        "authorization": "Bearer {auth}"
+      }
     }
   },
   "onelogin": {


### PR DESCRIPTION
Hi @simov
Here is a fix for okta provider with `query('oauth')`